### PR TITLE
Load mem test

### DIFF
--- a/mona3.py
+++ b/mona3.py
@@ -12507,6 +12507,12 @@ def procShowMODULES(args, procUsage = ""):
 	criteria={}
 	
 	modulecriteria,criteria = args2criteria(args,modulecriteria,criteria)
+
+	if "memory" in args and args["memory"]:
+		import windbglib3
+		windbglib3.VERSION_FROM_MEMORY = True
+		dbg.log("[+] Version info will be read from memory")
+
 	modulestosearch = getModulesToQuery(modulecriteria)
 	showModuleTable("",modulestosearch)
 	logfile = MnLog("modules.txt")
@@ -19379,7 +19385,9 @@ Mandatory argument :  -r <reg>  where reg is a valid register"""
 	ropfuncUsage = """Default module criteria : non aslr, non rebase, non os
 Output will be written to ropfunc.txt"""
 
-	modulesUsage = """Shows information about the loaded modules"""
+	modulesUsage = """Shows information about the loaded modules
+Optional parameters :
+-memory : read version info from the debuggee's live memory instead of from disk"""
 	
 	ropUsage="""Default module criteria : non aslr,non rebase,non os
 Optional parameters : 

--- a/mona3.py
+++ b/mona3.py
@@ -5988,7 +5988,7 @@ def getSearchSequences(searchtype,searchcriteria="",type="",criteria={}):
 	return search
 
 	
-def getModulesToQuery(criteria):
+def getModulesToQuery(criteria, from_memory=False):
 	"""
 	This function will return an array of modulenames
 	
@@ -5997,7 +5997,7 @@ def getModulesToQuery(criteria):
 	
 	Return:
 	array with module names that meet the given criteria
-	
+
 	"""	
 
 	if DEBUG_MODE:
@@ -6005,7 +6005,7 @@ def getModulesToQuery(criteria):
 		dbgp("function criteria: %s" % criteria)
 		dbgp("g_modules: %d entries" % len(g_modules))
 	if len(g_modules) == 0:
-		populateModuleInfo()
+		populateModuleInfo(from_memory=from_memory)
 	modulestoquery=[]
 	for thismodule,modproperties in g_modules.items():
 		#is this module excluded ?
@@ -6104,7 +6104,7 @@ def getModuleProperty(modname,parameter):
 	return valtoreturn
 
 
-def populateModuleInfo():
+def populateModuleInfo(from_memory=False):
 	"""
 	Populate global dictionary with information about all loaded modules
 	
@@ -6123,7 +6123,7 @@ def populateModuleInfo():
 	g_modules={}
 	if DEBUG_MODE:
 		dbgp("Enumerating modules via getAllModules")
-	allmodules=dbg.getAllModules()
+	allmodules=dbg.getAllModules(from_memory=from_memory)
 	if DEBUG_MODE:
 		dbgp("Number of modules found: %d" % len(allmodules))
 	curmod = ""
@@ -12508,12 +12508,11 @@ def procShowMODULES(args, procUsage = ""):
 	
 	modulecriteria,criteria = args2criteria(args,modulecriteria,criteria)
 
-	if "memory" in args and args["memory"]:
-		import windbglib3
-		windbglib3.VERSION_FROM_MEMORY = True
+	from_memory = "memory" in args and bool(args["memory"])
+	if from_memory:
 		dbg.log("[+] Version info will be read from memory")
 
-	modulestosearch = getModulesToQuery(modulecriteria)
+	modulestosearch = getModulesToQuery(modulecriteria, from_memory=from_memory)
 	showModuleTable("",modulestosearch)
 	logfile = MnLog("modules.txt")
 	thislog = logfile.reset()

--- a/windbglib3.py
+++ b/windbglib3.py
@@ -826,17 +826,21 @@ class VSVersionInfo(object):
 		return cls(data)
 
 	@classmethod
-	def from_memory(cls, modbase):
+	def from_memory(cls, modbase, read_memory=None):
 		"""
 		Construct a VSVersionInfo by reading RT_VERSION from a loaded module
-		in the debuggee's address space via pykd.
+		in the debuggee's address space.
 
 		Walks the in-memory PE headers starting at modbase to locate the
-		resource data directory, then traverses the RT_VERSION resource tree,
-		reading all data with pykd.loadBytes. Supports both PE32 and PE32+.
+		resource data directory, then traverses the RT_VERSION resource tree.
+		Supports both PE32 and PE32+.
 
 		Args:
-			modbase: Virtual base address (int) of the loaded module.
+			modbase:     Virtual base address (int) of the loaded module.
+			read_memory: Optional callable read_memory(addr, size) -> bytes.
+			             If None, falls back to pykd.loadBytes. Pass the
+			             Debugger instance (dbg) to use its readMemory method,
+			             which works across WinDBG and Immunity Debugger.
 
 		Returns:
 			VSVersionInfo instance.
@@ -845,20 +849,27 @@ class VSVersionInfo(object):
 			ValueError: If the headers are invalid, RT_VERSION is absent, or
 			            the VS_FIXEDFILEINFO signature is invalid.
 		"""
-		def mem_read(addr, size):
-			return bytes(bytearray(dbg.readMemory(addr, size)))
+		if read_memory is not None:
+			if hasattr(read_memory, 'readMemory'):
+				# A Debugger object was passed — use its readMemory method
+				_read = lambda addr, size: bytes(bytearray(read_memory.readMemory(addr, size)))
+			else:
+				# A bare callable was passed
+				_read = lambda addr, size: bytes(bytearray(read_memory(addr, size)))
+		else:
+			_read = lambda addr, size: bytes(bytearray(pykd.loadBytes(addr, size)))
 
 		def mem_dword(addr):
-			return struct.unpack("<I", mem_read(addr, 4))[0]
+			return struct.unpack("<I", _read(addr, 4))[0]
 
 		def mem_word(addr):
-			return struct.unpack("<H", mem_read(addr, 2))[0]
+			return struct.unpack("<H", _read(addr, 2))[0]
 
 		# DOS header -> NT header offset
 		nt_off = mem_dword(modbase + 0x3C)
 		nt_base = modbase + nt_off
 
-		if mem_read(nt_base, 4) != b"PE\x00\x00":
+		if _read(nt_base, 4) != b"PE\x00\x00":
 			raise ValueError("Not a valid PE file in memory at 0x%x" % modbase)
 
 		# COFF File Header
@@ -884,7 +895,7 @@ class VSVersionInfo(object):
 		sect_base = nt_base + 4 + 20 + size_opt_hdr
 		res_sec = None
 		for i in range(num_sections):
-			sd = mem_read(sect_base + i * 40, 40)
+			sd = _read(sect_base + i * 40, 40)
 			v_sz, v_addr = struct.unpack_from("<II", sd, 8)
 			if v_addr <= res_rva < v_addr + v_sz:
 				res_sec = (v_addr, modbase + v_addr)  # (rva, va)
@@ -898,9 +909,9 @@ class VSVersionInfo(object):
 			return modbase + rva
 
 		def read_dir_entries(dir_va):
-			hdr = mem_read(dir_va, 16)
+			hdr = _read(dir_va, 16)
 			num_named, num_id = struct.unpack("<HH", hdr[12:16])
-			entries_raw = mem_read(dir_va + 16, (num_named + num_id) * 8)
+			entries_raw = _read(dir_va + 16, (num_named + num_id) * 8)
 			count = num_named + num_id
 			return [struct.unpack_from("<II", entries_raw, i * 8) for i in range(count)]
 
@@ -930,29 +941,31 @@ class VSVersionInfo(object):
 		_, data_entry_off = lang_entries[0]
 
 		# IMAGE_RESOURCE_DATA_ENTRY
-		data_entry = mem_read(res_va + data_entry_off, 8)
+		data_entry = _read(res_va + data_entry_off, 8)
 		data_rva, data_size = struct.unpack("<II", data_entry)
-		data = mem_read(rva2va(data_rva), data_size)
+		data = _read(rva2va(data_rva), data_size)
 		return cls(data)
 
 	def __repr__(self):
 		return "VSVersionInfo(fixed=%r, string_tables=%r)" % (self.fixed, self.string_tables)
 
 
-def get_module_version(path, modbase=None, from_memory=False):
+def get_module_version(path, modbase=None, from_memory=False, debugger=None):
 	"""
 	Read the FileVersion of a PE module by parsing VS_VERSION_INFO.
 
 	When from_memory is True (or the global VERSION_FROM_MEMORY flag is set)
 	and modbase is provided, the resource data is read from the debuggee's live
-	address space via pykd (VSVersionInfo.from_memory). Otherwise the file at
-	path is read from disk (VSVersionInfo.from_file).
+	address space. Otherwise the file at path is read from disk.
 
 	Args:
 		path:        Filesystem path to the PE file (used for disk reads).
 		modbase:     Virtual base address of the loaded module (required for
 		             memory reads; ignored for disk reads).
 		from_memory: If True, force a memory read regardless of the global flag.
+		debugger:    Debugger instance whose readMemory() method is used for
+		             memory reads. Supports WinDBG (pykd) and Immunity Debugger.
+		             If None, pykd.loadBytes is used directly.
 
 	Returns:
 		Version string in 'major.minor.build.revision' format, or empty
@@ -960,7 +973,7 @@ def get_module_version(path, modbase=None, from_memory=False):
 	"""
 	try:
 		if (from_memory or VERSION_FROM_MEMORY) and modbase is not None:
-			return VSVersionInfo.from_memory(modbase).fixed.file_version_str
+			return VSVersionInfo.from_memory(modbase, read_memory=debugger).fixed.file_version_str
 		return VSVersionInfo.from_file(path).fixed.file_version_str
 	except Exception:
 		return ""
@@ -3105,7 +3118,7 @@ class Debugger:
 			try:
 				if DEBUG_MODE:
 					dbgp("    Trying to get version info (memory=%s)" % VERSION_FROM_MEMORY)
-				thismodversion = get_module_version(fullpath, modbase=thismodbase)
+				thismodversion = get_module_version(fullpath, modbase=thismodbase, debugger=self)
 				if DEBUG_MODE:
 					dbgp("    -> %s" % thismodversion)
 			except Exception as e:

--- a/windbglib3.py
+++ b/windbglib3.py
@@ -825,24 +825,142 @@ class VSVersionInfo(object):
 				raise ValueError("RT_VERSION resource not found")
 		return cls(data)
 
+	@classmethod
+	def from_memory(cls, modbase):
+		"""
+		Construct a VSVersionInfo by reading RT_VERSION from a loaded module
+		in the debuggee's address space via pykd.
+
+		Walks the in-memory PE headers starting at modbase to locate the
+		resource data directory, then traverses the RT_VERSION resource tree,
+		reading all data with pykd.loadBytes. Supports both PE32 and PE32+.
+
+		Args:
+			modbase: Virtual base address (int) of the loaded module.
+
+		Returns:
+			VSVersionInfo instance.
+
+		Raises:
+			ValueError: If the headers are invalid, RT_VERSION is absent, or
+			            the VS_FIXEDFILEINFO signature is invalid.
+		"""
+		def mem_read(addr, size):
+			return bytes(bytearray(dbg.readMemory(addr, size)))
+
+		def mem_dword(addr):
+			return struct.unpack("<I", mem_read(addr, 4))[0]
+
+		def mem_word(addr):
+			return struct.unpack("<H", mem_read(addr, 2))[0]
+
+		# DOS header -> NT header offset
+		nt_off = mem_dword(modbase + 0x3C)
+		nt_base = modbase + nt_off
+
+		if mem_read(nt_base, 4) != b"PE\x00\x00":
+			raise ValueError("Not a valid PE file in memory at 0x%x" % modbase)
+
+		# COFF File Header
+		num_sections = mem_word(nt_base + 4 + 2)
+		size_opt_hdr = mem_word(nt_base + 4 + 16)
+
+		# Optional Header magic
+		magic = mem_word(nt_base + 4 + 20)
+		if magic == 0x10b:
+			dd_off = nt_base + 4 + 20 + 96
+		elif magic == 0x20b:
+			dd_off = nt_base + 4 + 20 + 112
+		else:
+			raise ValueError("Unrecognised Optional Header magic: %s" % hex(magic))
+
+		# IMAGE_DATA_DIRECTORY[2] = resource directory
+		res_rva = mem_dword(dd_off + 2 * 8)
+		res_size = mem_dword(dd_off + 2 * 8 + 4)
+		if res_rva == 0:
+			raise ValueError("No resource data directory in memory")
+
+		# Parse section table to find the section that contains res_rva
+		sect_base = nt_base + 4 + 20 + size_opt_hdr
+		res_sec = None
+		for i in range(num_sections):
+			sd = mem_read(sect_base + i * 40, 40)
+			v_sz, v_addr = struct.unpack_from("<II", sd, 8)
+			if v_addr <= res_rva < v_addr + v_sz:
+				res_sec = (v_addr, modbase + v_addr)  # (rva, va)
+				break
+		if res_sec is None:
+			raise ValueError("Resource section not found in memory")
+
+		sec_rva, sec_va = res_sec
+
+		def rva2va(rva):
+			return modbase + rva
+
+		def read_dir_entries(dir_va):
+			hdr = mem_read(dir_va, 16)
+			num_named, num_id = struct.unpack("<HH", hdr[12:16])
+			entries_raw = mem_read(dir_va + 16, (num_named + num_id) * 8)
+			count = num_named + num_id
+			return [struct.unpack_from("<II", entries_raw, i * 8) for i in range(count)]
+
+		RT_VERSION = 16
+		res_va = rva2va(res_rva)
+
+		# Level 1: find RT_VERSION by type ID
+		type_entries = read_dir_entries(res_va)
+		type_off = next(
+			(off for id_, off in type_entries
+			 if not (id_ & 0x80000000) and id_ == RT_VERSION),
+			None
+		)
+		if type_off is None:
+			raise ValueError("RT_VERSION not found in in-memory resource directory")
+
+		# Level 2: first name entry
+		name_entries = read_dir_entries(res_va + (type_off & 0x7FFFFFFF))
+		if not name_entries:
+			raise ValueError("RT_VERSION has no name entries in memory")
+		_, lang_off = name_entries[0]
+
+		# Level 3: first language entry
+		lang_entries = read_dir_entries(res_va + (lang_off & 0x7FFFFFFF))
+		if not lang_entries:
+			raise ValueError("RT_VERSION has no language entries in memory")
+		_, data_entry_off = lang_entries[0]
+
+		# IMAGE_RESOURCE_DATA_ENTRY
+		data_entry = mem_read(res_va + data_entry_off, 8)
+		data_rva, data_size = struct.unpack("<II", data_entry)
+		data = mem_read(rva2va(data_rva), data_size)
+		return cls(data)
+
 	def __repr__(self):
 		return "VSVersionInfo(fixed=%r, string_tables=%r)" % (self.fixed, self.string_tables)
 
 
-def get_module_version(path):
+def get_module_version(path, modbase=None, from_memory=False):
 	"""
-	Read the FileVersion from a PE file on disk by parsing VS_VERSION_INFO
-	directly from the resource section, without relying on pykd.
-	Supports both PE32 (32-bit) and PE32+ (64-bit) images.
+	Read the FileVersion of a PE module by parsing VS_VERSION_INFO.
+
+	When from_memory is True (or the global VERSION_FROM_MEMORY flag is set)
+	and modbase is provided, the resource data is read from the debuggee's live
+	address space via pykd (VSVersionInfo.from_memory). Otherwise the file at
+	path is read from disk (VSVersionInfo.from_file).
 
 	Args:
-		path: Filesystem path to the PE file.
+		path:        Filesystem path to the PE file (used for disk reads).
+		modbase:     Virtual base address of the loaded module (required for
+		             memory reads; ignored for disk reads).
+		from_memory: If True, force a memory read regardless of the global flag.
 
 	Returns:
 		Version string in 'major.minor.build.revision' format, or empty
 		string if the version resource cannot be found or parsed.
 	"""
 	try:
+		if (from_memory or VERSION_FROM_MEMORY) and modbase is not None:
+			return VSVersionInfo.from_memory(modbase).fixed.file_version_str
 		return VSVersionInfo.from_file(path).fixed.file_version_str
 	except Exception:
 		return ""
@@ -2986,8 +3104,8 @@ class Debugger:
 
 			try:
 				if DEBUG_MODE:
-					dbgp("    Trying to get version info")
-				thismodversion = get_module_version(fullpath)
+					dbgp("    Trying to get version info (memory=%s)" % VERSION_FROM_MEMORY)
+				thismodversion = get_module_version(fullpath, modbase=thismodbase)
 				if DEBUG_MODE:
 					dbgp("    -> %s" % thismodversion)
 			except Exception as e:

--- a/windbglib3.py
+++ b/windbglib3.py
@@ -3118,7 +3118,7 @@ class Debugger:
 			try:
 				if DEBUG_MODE:
 					dbgp("    Trying to get version info (memory=%s)" % VERSION_FROM_MEMORY)
-				thismodversion = get_module_version(fullpath, modbase=thismodbase, debugger=self)
+				thismodversion = get_module_version(thismodpath, modbase=thismodbase, debugger=self)
 				if DEBUG_MODE:
 					dbgp("    -> %s" % thismodversion)
 			except Exception as e:

--- a/windbglib3.py
+++ b/windbglib3.py
@@ -954,15 +954,15 @@ def get_module_version(path, modbase=None, from_memory=False, debugger=None):
 	"""
 	Read the FileVersion of a PE module by parsing VS_VERSION_INFO.
 
-	When from_memory is True (or the global VERSION_FROM_MEMORY flag is set)
-	and modbase is provided, the resource data is read from the debuggee's live
-	address space. Otherwise the file at path is read from disk.
+	When from_memory is True and modbase is provided, the resource data is read
+	from the debuggee's live address space. Otherwise the file at path is read
+	from disk.
 
 	Args:
 		path:        Filesystem path to the PE file (used for disk reads).
 		modbase:     Virtual base address of the loaded module (required for
 		             memory reads; ignored for disk reads).
-		from_memory: If True, force a memory read regardless of the global flag.
+		from_memory: If True, read from the debuggee's memory instead of disk.
 		debugger:    Debugger instance whose readMemory() method is used for
 		             memory reads. Supports WinDBG (pykd) and Immunity Debugger.
 		             If None, pykd.loadBytes is used directly.
@@ -972,7 +972,7 @@ def get_module_version(path, modbase=None, from_memory=False, debugger=None):
 		string if the version resource cannot be found or parsed.
 	"""
 	try:
-		if (from_memory or VERSION_FROM_MEMORY) and modbase is not None:
+		if from_memory and modbase is not None:
 			return VSVersionInfo.from_memory(modbase, read_memory=debugger).fixed.file_version_str
 		return VSVersionInfo.from_file(path).fixed.file_version_str
 	except Exception:
@@ -3055,7 +3055,7 @@ class Debugger:
 	"""
 	Modules
 	"""
-	def getModule(self,modulename):
+	def getModule(self, modulename, from_memory=False):
 		if DEBUG_MODE:
 			dbgp(get_current_function_name())
 			dbgp("------")
@@ -3117,8 +3117,8 @@ class Debugger:
 
 			try:
 				if DEBUG_MODE:
-					dbgp("    Trying to get version info (memory=%s)" % VERSION_FROM_MEMORY)
-				thismodversion = get_module_version(thismodpath, modbase=thismodbase, debugger=self)
+					dbgp("    Trying to get version info (memory=%s)" % from_memory)
+				thismodversion = get_module_version(fullpath, modbase=thismodbase, from_memory=from_memory, debugger=self)
 				if DEBUG_MODE:
 					dbgp("    -> %s" % thismodversion)
 			except Exception as e:
@@ -3158,7 +3158,7 @@ class Debugger:
 		return wmod
 		
 
-	def getAllModules(self):
+	def getAllModules(self, from_memory=False):
 		if DEBUG_MODE:
 			dbgp(get_current_function_name())
 
@@ -3171,7 +3171,7 @@ class Debugger:
 					dbgp("Modules in list now: %d" % len(PEBModList))
 			for imagename in PEBModList:
 				thismodname = PEBModList[imagename][0]
-				wmodobject = self.getModule(imagename)
+				wmodobject = self.getModule(imagename, from_memory=from_memory)
 				self.allmodules[thismodname] = wmodobject
 		return self.allmodules
 


### PR DESCRIPTION
Creates also a version of procShowModules that loads from memory instead of loading from the filesystem.


```

!mona modules [-memory]
        │
        ▼
procShowMODULES(args)
  from_memory = "memory" in args and bool(args["memory"])
        │
        ▼
getModulesToQuery(modulecriteria, from_memory=from_memory)   [mona3.py]
  └─ if g_modules is empty:
        │
        ▼
  populateModuleInfo(from_memory=from_memory)   [mona3.py]
        │
        ▼
  dbg.getAllModules(from_memory=from_memory)   [windbglib3.py :: Debugger]
        │
        ▼
  self.getModule(imagename, from_memory=from_memory)   [windbglib3.py :: Debugger]
        │
        ▼
  get_module_version(fullpath, modbase=thismodbase,
                     from_memory=from_memory, debugger=self)   [windbglib3.py]
        │
        ├─── from_memory=False ────────────────────────────────────┐
        │                                                           │
        ▼                                                           ▼
  VSVersionInfo.from_file(path)                   VSVersionInfo.from_memory(modbase,
        │                                                   read_memory=debugger)
        ▼                                                           │
  open(path, 'rb')                                                  │
        │                              ┌───────────────────────────┤
        │                              │ debugger is Debugger      │ debugger is None
        │                              ▼                            ▼
        │                  _read = lambda addr, size:    _read = lambda addr, size:
        │                    bytes(bytearray(               bytes(bytearray(
        │                      debugger.readMemory(           pykd.loadBytes(
        │                        addr, size)))                  addr, size)))
        │                              │                            │
        └──────────────────────────────┴────────────────────────────┘
                                       │
                                       ▼
                          _pe_parse_sections(f_or_mem, nt_off)
                                       │
                                       ▼
                          _pe_get_resource_dd(f_or_mem, nt_off)
                                       │
                                       ▼
                          _pe_get_rt_version_data(f_or_mem, sections, res_rva)
                                       │
                                       ▼
                               VSVersionInfo(data)
                                       │
                          ┌────────────┴────────────┐
                          ▼                          ▼
                   FixedFileInfo              StringTable(s)
                  .file_version_str          .get(key), [key]
                          │
                          ▼
           return version string  (e.g. "6.1.7601.17514")
                          │
                          ▼
         stored in g_modules[key]["version"]
                          │
                          ▼
             showModuleTable("", modulestosearch)   [mona3.py]

```