### PR TITLE
Add ordering and path filtering to the module list

### DIFF
--- a/mona3.py
+++ b/mona3.py
@@ -6040,6 +6040,13 @@ def getModulesToQuery(criteria, from_memory=False, peb_order="load"):
 				included = False				
 		else:
 			included = False
+		# filter by path regex ?
+		if included and ("cmp" in criteria) and criteria["cmp"]:
+			try:
+				if not re.search(criteria["cmp"], str(thismod.modulePath), re.IGNORECASE):
+					included = False
+			except re.error:
+				included = False
 		#override all previous decision if "modules" criteria was provided
 		thismodkey = thismod.moduleKey.lower().strip()
 		if ("modules" in criteria) and (criteria["modules"] != ""):
@@ -12090,6 +12097,17 @@ def args2criteria(args,modulecriteria,criteria):
 	if "o" in args and args["o"]:
 		modulecriteria["os"] = False
 		dbg.log("    - Ignoring OS modules")
+
+	# filter modules by path ?
+	if "cmp" in args and args["cmp"]:
+		pattern = str(args["cmp"])
+		try:
+			re.compile(pattern)
+		except re.error as e:
+			dbg.log("[!] Invalid regex for -cmp: %s" % e)
+			return modulecriteria, criteria
+		modulecriteria["cmp"] = pattern
+		dbg.log("    - Filtering modules by path matching : %s" % pattern)
 	
 	# allow nulls ?
 	if "n" in args and args["n"]:
@@ -19402,6 +19420,8 @@ def procHelp(args, procUsage = ""):
 	dbg.log(" -n                     : Skip modules that start with a null byte. If this is too broad, use")
 	dbg.log("                          option -cp nonull instead")
 	dbg.log(" -o                     : Ignore OS modules")
+	dbg.log(" -cmp <regex>           : Only include modules whose full path matches the given regex (case-insensitive)")
+	dbg.log("                          Example : -cmp kernel32  -cmp \"C:\\\\Windows\"  -cmp \"\\.dll$\"")
 	dbg.log(" -p <nr>                : Stop search after <nr> pointers.")
 	dbg.log(" -m <module,module,...> : only query the given modules. Be sure what you are doing !")
 	dbg.log("                          You can specify multiple modules (comma separated)")
@@ -19504,7 +19524,7 @@ Output will be written to ropfunc.txt"""
 
 	modulesUsage = """Shows information about the loaded modules
 Optional parameters :
--memory : read version info from the debuggee's live memory instead of from disk
+-memory       : read version info from the debuggee's live memory instead of from disk
 -sort <order> : select sort order for the output (default: load)
                 PEB list traversal order:
                   load    - InLoadOrderModuleList (DLL load order, default)

--- a/mona3.py
+++ b/mona3.py
@@ -6116,7 +6116,7 @@ def getModuleProperty(modname,parameter):
 	return valtoreturn
 
 
-def populateModuleInfo(from_memory=False):
+def populateModuleInfo(from_memory=False, peb_order="load"):
 	"""
 	Populate global dictionary with information about all loaded modules
 	
@@ -6136,7 +6136,7 @@ def populateModuleInfo(from_memory=False):
 	if DEBUG_MODE:
 		dbgp("Enumerating modules via getAllModules")
 	if __DEBUGGERAPP__ == "WinDBG":
-		allmodules=dbg.getAllModules(from_memory=from_memory)
+		allmodules=dbg.getAllModules(from_memory=from_memory, peb_order=peb_order)
 	else:
 		allmodules=dbg.getAllModules()
 	if DEBUG_MODE:

--- a/mona3.py
+++ b/mona3.py
@@ -176,6 +176,7 @@ TOP_USERLAND = 0x7fffffff if arch == 32 else 0x7FFFFFFFFFFF
 STACK_POINTER = "ESP" if arch == 32 else "RSP"
 PTR_SIZE_DIRECTIVE = "DWORD PTR" if arch == 32 else "QWORD PTR"
 g_modules={}
+g_modulesOrder=None
 MemoryPageACL={}
 global CritCache
 global vtableCache
@@ -6016,7 +6017,7 @@ def getModulesToQuery(criteria, from_memory=False, peb_order="load"):
 		dbgp(get_current_function_name())
 		dbgp("function criteria: %s" % criteria)
 		dbgp("g_modules: %d entries" % len(g_modules))
-	if len(g_modules) == 0:
+	if len(g_modules) == 0 or g_modulesOrder != peb_order:
 		populateModuleInfo(from_memory=from_memory, peb_order=peb_order)
 	modulestoquery=[]
 	for thismodule,modproperties in g_modules.items():
@@ -6131,7 +6132,7 @@ def populateModuleInfo(from_memory=False, peb_order="load"):
 		dbg.log("[+] Generating module info table, hang on...")
 		dbg.log("    - Processing modules")
 		#dbg.updateLog()
-	global g_modules
+	global g_modules, g_modulesOrder
 	g_modules={}
 	if DEBUG_MODE:
 		dbgp("Enumerating modules via getAllModules")
@@ -6182,6 +6183,7 @@ def populateModuleInfo(from_memory=False, peb_order="load"):
 		dbg.log("    - Done. Let's rock 'n roll.")
 		dbg.setStatusBar("")	
 		dbg.updateLog()
+	g_modulesOrder = peb_order
 
 def ModInfoCached(modulename):
 	"""

--- a/mona3.py
+++ b/mona3.py
@@ -6200,7 +6200,7 @@ def ModInfoCached(modulename):
 	else:
 		return True
 
-def showModuleTable(logfile="", modules=[]):
+def showModuleTable(logfile="", modules=[], sort_by=None, sort_order=None):
 	"""
 	Shows table with all loaded modules and their properties.
 
@@ -6209,7 +6209,9 @@ def showModuleTable(logfile="", modules=[]):
 	or
 	filename - output will be written to the filename
 	
-	modules - dictionary with modules to query - result of a populateModuleInfo() call
+	modules    - dictionary with modules to query - result of a populateModuleInfo() call
+	sort_by    - optional post-traversal sort key (see POST_SORT_VALID)
+	sort_order - 'asc' or 'desc'; overrides the default direction for the chosen key
 	"""	
 	thistable = ""
 	if len(g_modules) == 0:
@@ -6223,7 +6225,27 @@ def showModuleTable(logfile="", modules=[]):
 		thistable += " Base               | Top                | Size               | Rebase | SafeSEH | ASLR  | CFG   | NXCompat | OS Dll | Version, Modulename & Path, DLLCharacteristics\n"
 	thistable += "----------------------------------------------------------------------------------------------------------------------------------------------\n"
 
-	for thismodule,modproperties in g_modules.items():
+	_POST_SORT_KEYS = {
+		"base":    lambda x: x[1]["base"],
+		"size":    lambda x: x[1]["size"],
+		"rebase":  lambda x: x[1]["rebase"],
+		"safeseh": lambda x: x[1]["safeseh"],
+		"aslr":    lambda x: x[1]["aslr"],
+		"cfg":     lambda x: x[1]["cfg"],
+		"nx":      lambda x: x[1]["nx"],
+		"os":      lambda x: x[1]["os"],
+	}
+	items = list(g_modules.items())
+	if sort_by in _POST_SORT_KEYS:
+		default_reverse = _POST_SORT_DEFAULT_REVERSE.get(sort_by, False)
+		if sort_order == "asc":
+			reverse = False
+		elif sort_order == "desc":
+			reverse = True
+		else:
+			reverse = default_reverse
+		items = sorted(items, key=_POST_SORT_KEYS[sort_by], reverse=reverse)
+	for thismodule,modproperties in items:
 		if (len(modules) > 0 and modproperties["name"] in modules or len(logfile)>0):
 			rebase	= toSize(str(modproperties["rebase"]),7)
 			base 	= toSize(str("0x" + toHex(modproperties["base"])),10)
@@ -12524,6 +12546,19 @@ def procFindSEH(args, procUsage=""):
 	
 # ----- MODULES ------ #
 PEB_ORDER_VALID = ("load", "memory", "init")
+POST_SORT_VALID = ("base", "size", "rebase", "safeseh", "aslr", "cfg", "nx", "os")
+# For boolean sorts, True-first is considered 'desc' (default); False-first is 'asc'
+# For numeric sorts, ascending is default; 'desc' reverses
+_POST_SORT_DEFAULT_REVERSE = {
+	"base":    False,
+	"size":    False,
+	"rebase":  True,
+	"safeseh": True,
+	"aslr":    True,
+	"cfg":     True,
+	"nx":      True,
+	"os":      True,
+}
 
 def procShowMODULES(args, procUsage = ""):
 	modulecriteria={}
@@ -12536,14 +12571,27 @@ def procShowMODULES(args, procUsage = ""):
 		dbg.log("[+] Version info will be read from memory")
 
 	peb_order = "load"
+	sort_by = None
+	sort_order = None
 	if "sort" in args and args["sort"]:
-		peb_order = str(args["sort"]).lower().strip()
-		if peb_order not in PEB_ORDER_VALID:
-			dbg.log("[!] Unknown sort value '%s', valid options: %s" % (peb_order, ", ".join(PEB_ORDER_VALID)))
+		sort_val = str(args["sort"]).lower().strip()
+		if sort_val in PEB_ORDER_VALID:
+			peb_order = sort_val
+		elif sort_val in POST_SORT_VALID:
+			sort_by = sort_val
+		else:
+			all_valid = ", ".join(PEB_ORDER_VALID + POST_SORT_VALID)
+			dbg.log("[!] Unknown sort value '%s', valid options: %s" % (sort_val, all_valid))
 			return
+	if sort_by is not None and "order" in args and args["order"]:
+		order_val = str(args["order"]).lower().strip()
+		if order_val not in ("asc", "desc"):
+			dbg.log("[!] Unknown order value '%s', valid options: asc, desc" % order_val)
+			return
+		sort_order = order_val
 
 	modulestosearch = getModulesToQuery(modulecriteria, from_memory=from_memory, peb_order=peb_order)
-	showModuleTable("", modulestosearch)
+	showModuleTable("", modulestosearch, sort_by=sort_by, sort_order=sort_order)
 	logfile = MnLog("modules.txt")
 	thislog = logfile.reset()
 
@@ -19457,10 +19505,23 @@ Output will be written to ropfunc.txt"""
 	modulesUsage = """Shows information about the loaded modules
 Optional parameters :
 -memory : read version info from the debuggee's live memory instead of from disk
--sort <order> : select PEB LDR_DATA list order for the output (default: load)
-                load   - InLoadOrderModuleList (DLL load order)
-                memory - InMemoryOrderModuleList (ascending base address)
-                init   - InInitializationOrderModuleList (DllMain call order)"""
+-sort <order> : select sort order for the output (default: load)
+                PEB list traversal order:
+                  load    - InLoadOrderModuleList (DLL load order, default)
+                  memory  - InMemoryOrderModuleList
+                  init    - InInitializationOrderModuleList (DllMain order)
+                Post-traversal sort (applied after PEB walk):
+                  base    - ascending base address
+                  size    - ascending module size
+                  rebase  - modules with Rebase=True first
+                  safeseh - modules with SafeSEH=True first
+                  aslr    - modules with ASLR=True first
+                  cfg     - modules with CFG=True first
+                  nx      - modules with NXCompat=True first
+                  os      - modules with OS Dll=True first
+-order <dir>  : override sort direction (only valid with a post-traversal -sort)
+                  asc   - ascending / False-first for boolean keys
+                  desc  - descending / True-first for boolean keys (default for boolean keys)"""
 	
 	ropUsage="""Default module criteria : non aslr,non rebase,non os
 Optional parameters : 

--- a/mona3.py
+++ b/mona3.py
@@ -12101,6 +12101,9 @@ def args2criteria(args,modulecriteria,criteria):
 	# filter modules by path ?
 	if "cmp" in args and args["cmp"]:
 		pattern = str(args["cmp"])
+		# convert glob wildcards (* and ?) to regex equivalents so that
+		# patterns like *system32* work as expected; raw regex still works
+		pattern = pattern.replace("*", ".*").replace("?", ".")
 		try:
 			re.compile(pattern)
 		except re.error as e:

--- a/mona3.py
+++ b/mona3.py
@@ -6000,7 +6000,7 @@ def getSearchSequences(searchtype,searchcriteria="",type="",criteria={}):
 	return search
 
 	
-def getModulesToQuery(criteria, from_memory=False):
+def getModulesToQuery(criteria, from_memory=False, peb_order="load"):
 	"""
 	This function will return an array of modulenames
 	
@@ -6017,7 +6017,7 @@ def getModulesToQuery(criteria, from_memory=False):
 		dbgp("function criteria: %s" % criteria)
 		dbgp("g_modules: %d entries" % len(g_modules))
 	if len(g_modules) == 0:
-		populateModuleInfo(from_memory=from_memory)
+		populateModuleInfo(from_memory=from_memory, peb_order=peb_order)
 	modulestoquery=[]
 	for thismodule,modproperties in g_modules.items():
 		#is this module excluded ?
@@ -12521,6 +12521,8 @@ def procFindSEH(args, procUsage=""):
 	
 	
 # ----- MODULES ------ #
+PEB_ORDER_VALID = ("load", "memory", "init")
+
 def procShowMODULES(args, procUsage = ""):
 	modulecriteria={}
 	criteria={}
@@ -12531,8 +12533,15 @@ def procShowMODULES(args, procUsage = ""):
 	if from_memory:
 		dbg.log("[+] Version info will be read from memory")
 
-	modulestosearch = getModulesToQuery(modulecriteria, from_memory=from_memory)
-	showModuleTable("",modulestosearch)
+	peb_order = "load"
+	if "sort" in args and args["sort"]:
+		peb_order = str(args["sort"]).lower().strip()
+		if peb_order not in PEB_ORDER_VALID:
+			dbg.log("[!] Unknown sort value '%s', valid options: %s" % (peb_order, ", ".join(PEB_ORDER_VALID)))
+			return
+
+	modulestosearch = getModulesToQuery(modulecriteria, from_memory=from_memory, peb_order=peb_order)
+	showModuleTable("", modulestosearch)
 	logfile = MnLog("modules.txt")
 	thislog = logfile.reset()
 
@@ -19445,7 +19454,11 @@ Output will be written to ropfunc.txt"""
 
 	modulesUsage = """Shows information about the loaded modules
 Optional parameters :
--memory : read version info from the debuggee's live memory instead of from disk"""
+-memory : read version info from the debuggee's live memory instead of from disk
+-sort <order> : select PEB LDR_DATA list order for the output (default: load)
+                load   - InLoadOrderModuleList (DLL load order)
+                memory - InMemoryOrderModuleList (ascending base address)
+                init   - InInitializationOrderModuleList (DllMain call order)"""
 	
 	ropUsage="""Default module criteria : non aslr,non rebase,non os
 Optional parameters : 

--- a/windbglib3.py
+++ b/windbglib3.py
@@ -1084,11 +1084,11 @@ def getModulesFromPEB(peb_order="load"):
 							addtolist = False
 
 			if addtolist:
-			imagenames.append(imagename)
-			PEBModList[imagename] = [exename, fullpath]
-			if DEBUG_MODE:
-				dbgp("    Added %s to PEBModList" % imagename)
-				dbgp("    With full path %s" % fullpath)
+				imagenames.append(imagename)
+				PEBModList[imagename] = [exename, fullpath]
+				if DEBUG_MODE:
+					dbgp("    Added %s to PEBModList" % imagename)
+					dbgp("    With full path %s" % fullpath)
 	_PEBModListOrder = peb_order
 
 

--- a/windbglib3.py
+++ b/windbglib3.py
@@ -82,6 +82,7 @@ PageSections = {}
 ModuleCache = {}
 FuncCache = {}
 PEBModList = {}
+_PEBModListOrder = None
 disAsmCache = {}
 
 Registers32BitsOrder = ["EAX", "ECX", "EDX", "EBX", "ESP", "EBP", "ESI", "EDI"]
@@ -988,11 +989,17 @@ def get_module_version(path, modbase=None, from_memory=False, debugger=None):
 		return ""
 
 
-def getModulesFromPEB():
+_PEB_LDR_LISTS = {
+	"load":   ("InLoadOrderModuleList",           "InLoadOrderLinks.Flink"),
+	"memory": ("InMemoryOrderModuleList",          "InMemoryOrderLinks.Flink"),
+	"init":   ("InInitializationOrderModuleList",  "InInitializationOrderLinks.Flink"),
+}
+
+def getModulesFromPEB(peb_order="load"):
 	if DEBUG_MODE:
 		dbgp(get_current_function_name())
 
-	global PEBModList
+	global PEBModList, _PEBModListOrder
 	peb = getPEBInfo()
 	imagenames = []
 	# http://www.nirsoft.net/kernel_struct/vista/PEB.html
@@ -1002,9 +1009,12 @@ def getModulesFromPEB():
 	offset = 0x20
 	if arch == 64:
 		offset = 0x40
-	moduleLst = pykd.typedVarList(peb.Ldr.deref().InLoadOrderModuleList, "ntdll!_LDR_DATA_TABLE_ENTRY", "InLoadOrderLinks.Flink")
+	list_attr, flink_attr = _PEB_LDR_LISTS.get(peb_order, _PEB_LDR_LISTS["load"])
+	moduleLst = pykd.typedVarList(getattr(peb.Ldr.deref(), list_attr), "ntdll!_LDR_DATA_TABLE_ENTRY", flink_attr)
 	if DEBUG_MODE:
-		dbgp("moduleList: %d, PEBModlist: %d" % (len(moduleLst), len(PEBModList)))
+		dbgp("moduleList: %d, PEBModlist: %d, order: %s" % (len(moduleLst), len(PEBModList), peb_order))
+	if len(PEBModList) != 0 and _PEBModListOrder != peb_order:
+		PEBModList = {}
 	if len(PEBModList) == 0:
 		for mod in moduleLst:
 			thismod = ensure_text(pykd.loadUnicodeString(mod.BaseDllName))
@@ -1074,13 +1084,12 @@ def getModulesFromPEB():
 							addtolist = False
 
 			if addtolist:
-				imagenames.append(imagename)
-				PEBModList[imagename] = [exename, fullpath]
-				if DEBUG_MODE:
-					dbgp("    Added %s to PEBModList" % imagename)
-					dbgp("    With full path %s" % fullpath)
-	
-	return moduleLst
+			imagenames.append(imagename)
+			PEBModList[imagename] = [exename, fullpath]
+			if DEBUG_MODE:
+				dbgp("    Added %s to PEBModList" % imagename)
+				dbgp("    With full path %s" % fullpath)
+	_PEBModListOrder = peb_order
 
 
 
@@ -3184,15 +3193,17 @@ class Debugger:
 		return wmod
 		
 
-	def getAllModules(self, from_memory=False):
+	def getAllModules(self, from_memory=False, peb_order="load"):
 		if DEBUG_MODE:
 			dbgp(get_current_function_name())
 
+		if peb_order != _PEBModListOrder and len(self.allmodules) > 0:
+			self.allmodules = {}
 		if len(self.allmodules) == 0:
-			if len(PEBModList) == 0:
+			if len(PEBModList) == 0 or peb_order != _PEBModListOrder:
 				if DEBUG_MODE:
-					dbgp("Get modules from PEB")
-				getModulesFromPEB()
+					dbgp("Get modules from PEB (order=%s)" % peb_order)
+				getModulesFromPEB(peb_order=peb_order)
 				if DEBUG_MODE:
 					dbgp("Modules in list now: %d" % len(PEBModList))
 			for imagename in PEBModList:


### PR DESCRIPTION
This change adds the following:

## global options
-`cmp <pattern>`: Filter the module list by full path. The pattern is matched case-insensitively. 
Glob wildcards are supported (`*` = any sequence of characters, `?` = any single character), and raw regex patterns also work.

Examples: `-cmp *system32*`, `-cmp kernel32`, `-cmp "C:\\Windows"`, `-cmp "\.dll$"`

Works on any command that queries modules (e.g. `!mona modules`, `!mona rop`, `!mona seh`, …).

## command flags (`!mona modules` only)
-`sort <order>`: Controls the order in which modules appear in the output.

### PEB list traversal order (determines which `LDR_DATA_TABLE_ENTRY` list is walked):
`load` (default) — `InLoadOrderModuleList`
`memory` — `InMemoryOrderModuleList`
`init` — `InInitializationOrderModuleList` (DllMain call order)

### Post-traversal sort (applied after the PEB walk, to the already-populated module table):
-`base` — ascending base address
-`size` — ascending module size
-`rebase` / `safeseh` / `aslr` / `cfg` / `nx` / `os` — modules where that flag is True first
-`order <asc|desc>` : Overrides the default sort direction. Only meaningful when a post-traversal -sort key is used.
  - `desc` (default for boolean keys) — True-first
  - `asc` (default for base/size) — ascending / False-first for boolean keys