### PR TITLE
Change modules sort default behavior and version detecting fallback strategy

### DIFF
--- a/mona3.py
+++ b/mona3.py
@@ -3072,10 +3072,29 @@ class MnModule:
 					mversion="-1.0-"
 				path     = mod.getPath()
 				filename = os.path.basename(path)
-				if mod.getIssystemdll() == 0:
-					modisos = "WINDOWS" in path.upper()
+
+				_OS_PRODUCT_NAME = "Microsoft\u00ae Windows\u00ae Operating System"
+				if __DEBUGGERAPP__ == "WinDBG":
+					modisos = False
+					try:
+						vi = dbglib.VSVersionInfo.from_memory(mzbase, read_memory=dbg)
+						if vi is None or not vi.fixed.file_version_str:
+							vi = dbglib.VSVersionInfo.from_file(path)
+					except Exception:
+						try:
+							vi = dbglib.VSVersionInfo.from_file(path)
+						except Exception:
+							vi = None
+					if vi is not None:
+						for st in vi.string_tables:
+							if st.get("ProductName", "").strip() == _OS_PRODUCT_NAME:
+								modisos = True
+								break
 				else:
-					modisos = True
+					if mod.getIssystemdll() == 0:
+						modisos = "WINDOWS" in path.upper()
+					else:
+						modisos = True
 
 				mztop = mzbase + mzsize
 				if mzbase > 0:

--- a/mona3.py
+++ b/mona3.py
@@ -6591,12 +6591,13 @@ def showModuleTable(logfile="", modules=[], sort_by=None, sort_order=None):
 	_POST_SORT_KEYS = {
 		"base":    lambda x: x[1]["base"],
 		"size":    lambda x: x[1]["size"],
-		"rebase":  lambda x: x[1]["rebase"],
-		"safeseh": lambda x: x[1]["safeseh"],
-		"aslr":    lambda x: x[1]["aslr"],
-		"cfg":     lambda x: x[1]["cfg"],
-		"nx":      lambda x: x[1]["nx"],
-		"os":      lambda x: x[1]["os"],
+		# boolean keys: negate so that ascending order puts True first
+		"rebase":  lambda x: not x[1]["rebase"],
+		"safeseh": lambda x: not x[1]["safeseh"],
+		"aslr":    lambda x: not x[1]["aslr"],
+		"cfg":     lambda x: not x[1]["cfg"],
+		"nx":      lambda x: not x[1]["nx"],
+		"os":      lambda x: not x[1]["os"],
 	}
 	items = list(g_modules.items())
 	if sort_by in _POST_SORT_KEYS:
@@ -12983,17 +12984,18 @@ def procFindSEH(args, procUsage=""):
 # ----- MODULES ------ #
 PEB_ORDER_VALID = ("load", "memory", "init")
 POST_SORT_VALID = ("base", "size", "rebase", "safeseh", "aslr", "cfg", "nx", "os")
-# For boolean sorts, True-first is considered 'desc' (default); False-first is 'asc'
-# For numeric sorts, ascending is default; 'desc' reverses
+# For boolean sorts: keys are negated, so ascending (reverse=False) puts True first.
+# -order asc = True-first, -order desc = False-first.
+# For numeric sorts: ascending (reverse=False) is the default.
 _POST_SORT_DEFAULT_REVERSE = {
 	"base":    False,
 	"size":    False,
-	"rebase":  True,
-	"safeseh": True,
-	"aslr":    True,
-	"cfg":     True,
-	"nx":      True,
-	"os":      True,
+	"rebase":  False,
+	"safeseh": False,
+	"aslr":    False,
+	"cfg":     False,
+	"nx":      False,
+	"os":      False,
 }
 
 def procShowMODULES(args):
@@ -13002,23 +13004,22 @@ def procShowMODULES(args):
 	
 	modulecriteria,criteria = args2criteria(args,modulecriteria,criteria)
 
-	from_memory = "memory" in args and bool(args["memory"])
-	if from_memory:
-		dbg.log("[+] Version info will be read from memory")
-
 	peb_order = "load"
+	if "peborder" in args and args["peborder"]:
+		peb_val = str(args["peborder"]).lower().strip()
+		if peb_val not in PEB_ORDER_VALID:
+			dbg.log("[!] Unknown -peborder value '%s', valid options: %s" % (peb_val, ", ".join(PEB_ORDER_VALID)))
+			return
+		peb_order = peb_val
+
 	sort_by = None
 	sort_order = None
 	if "sort" in args and args["sort"]:
 		sort_val = str(args["sort"]).lower().strip()
-		if sort_val in PEB_ORDER_VALID:
-			peb_order = sort_val
-		elif sort_val in POST_SORT_VALID:
-			sort_by = sort_val
-		else:
-			all_valid = ", ".join(PEB_ORDER_VALID + POST_SORT_VALID)
-			dbg.log("[!] Unknown sort value '%s', valid options: %s" % (sort_val, all_valid))
+		if sort_val not in POST_SORT_VALID:
+			dbg.log("[!] Unknown sort value '%s', valid options: %s" % (sort_val, ", ".join(POST_SORT_VALID)))
 			return
+		sort_by = sort_val
 	if sort_by is not None and "order" in args and args["order"]:
 		order_val = str(args["order"]).lower().strip()
 		if order_val not in ("asc", "desc"):
@@ -13026,7 +13027,7 @@ def procShowMODULES(args):
 			return
 		sort_order = order_val
 
-	modulestosearch = getModulesToQuery(modulecriteria, from_memory=from_memory, peb_order=peb_order)
+	modulestosearch = getModulesToQuery(modulecriteria, from_memory=True, peb_order=peb_order)
 	showModuleTable("", modulestosearch, sort_by=sort_by, sort_order=sort_order)
 	logfile = MnLog("modules.txt")
 	thislog = logfile.reset()
@@ -19942,7 +19943,19 @@ Mandatory argument :  -r <reg>  where reg is a valid register"""
 Output will be written to ropfunc.txt"""
 	
 	modulesUsage = """Shows information about the loaded modules.
-Check the global options above to filter and/or sort the modules as needed"""
+Check the global options above to filter modules as needed.
+Optional parameters :
+-peborder <list>   : select which PEB LDR_DATA list to walk (default: load)
+                       load   - InLoadOrderModuleList (DLL load order)
+                       memory - InMemoryOrderModuleList
+                       init   - InInitializationOrderModuleList (DllMain call order)
+-sort <key>        : sort the output after the PEB walk
+                       base    - ascending base address
+                       size    - ascending module size
+                       rebase / safeseh / aslr / cfg / nx / os - True-first
+-order <dir>       : override sort direction (only valid with -sort)
+                       asc   - ascending for numeric keys; True-first for boolean keys (default)
+                       desc  - descending for numeric keys; False-first for boolean keys"""
 	
 	ropUsage="""Default module criteria : non aslr,non rebase,non os
 Optional parameters : 

--- a/mona3.py
+++ b/mona3.py
@@ -6591,13 +6591,13 @@ def showModuleTable(logfile="", modules=[], sort_by=None, sort_order=None):
 	_POST_SORT_KEYS = {
 		"base":    lambda x: x[1]["base"],
 		"size":    lambda x: x[1]["size"],
-		# boolean keys: negate so that ascending order puts True first
-		"rebase":  lambda x: not x[1]["rebase"],
-		"safeseh": lambda x: not x[1]["safeseh"],
-		"aslr":    lambda x: not x[1]["aslr"],
-		"cfg":     lambda x: not x[1]["cfg"],
-		"nx":      lambda x: not x[1]["nx"],
-		"os":      lambda x: not x[1]["os"],
+		# boolean keys: False=0 sorts before True=1 in ascending order (False-first default)
+		"rebase":  lambda x: x[1]["rebase"],
+		"safeseh": lambda x: x[1]["safeseh"],
+		"aslr":    lambda x: x[1]["aslr"],
+		"cfg":     lambda x: x[1]["cfg"],
+		"nx":      lambda x: x[1]["nx"],
+		"os":      lambda x: x[1]["os"],
 	}
 	items = list(g_modules.items())
 	if sort_by in _POST_SORT_KEYS:
@@ -12984,8 +12984,8 @@ def procFindSEH(args, procUsage=""):
 # ----- MODULES ------ #
 PEB_ORDER_VALID = ("load", "memory", "init")
 POST_SORT_VALID = ("base", "size", "rebase", "safeseh", "aslr", "cfg", "nx", "os")
-# For boolean sorts: keys are negated, so ascending (reverse=False) puts True first.
-# -order asc = True-first, -order desc = False-first.
+# For boolean sorts: False=0 sorts before True=1, so ascending (reverse=False) puts False first.
+# -order asc = False-first (default), -order desc = True-first.
 # For numeric sorts: ascending (reverse=False) is the default.
 _POST_SORT_DEFAULT_REVERSE = {
 	"base":    False,
@@ -19954,8 +19954,8 @@ Optional parameters :
                        size    - ascending module size
                        rebase / safeseh / aslr / cfg / nx / os - True-first
 -order <dir>       : override sort direction (only valid with -sort)
-                       asc   - ascending for numeric keys; True-first for boolean keys (default)
-                       desc  - descending for numeric keys; False-first for boolean keys"""
+                       asc   - ascending for numeric keys; False-first for boolean keys (default)
+                       desc  - descending for numeric keys; True-first for boolean keys"""
 	
 	ropUsage="""Default module criteria : non aslr,non rebase,non os
 Optional parameters : 

--- a/windbglib3.py
+++ b/windbglib3.py
@@ -982,9 +982,15 @@ def get_module_version(path, modbase=None, from_memory=False, debugger=None):
 		Version string in 'major.minor.build.revision' format, or empty
 		string if the version resource cannot be found or parsed.
 	"""
+	if from_memory and modbase is not None:
+		try:
+			result = VSVersionInfo.from_memory(modbase, read_memory=debugger).fixed.file_version_str
+			if result:
+				return result
+		except Exception:
+			pass
+	# fall back to disk (memory read unavailable, raised, or returned empty)
 	try:
-		if from_memory and modbase is not None:
-			return VSVersionInfo.from_memory(modbase, read_memory=debugger).fixed.file_version_str
 		return VSVersionInfo.from_file(path).fixed.file_version_str
 	except Exception:
 		return ""


### PR DESCRIPTION
Removed the from_memory / `-filesystem` user-facing flag. 
Version info is now always read with a memory-first, filesystem-fallback strategy automatically — no flag needed.

Changed default order in Sort on boolean values to be False-first.

Updated OS detection to look into `VS_VERSIONINFO` and check the ProductName, to match Windows's product name.