### PR TITLE
Compare command -cpb option

### DIFF
--- a/mona.py
+++ b/mona.py
@@ -240,7 +240,7 @@ guessedAlias = ""
 aliasname = ""
 
 # cache
-# 
+#
 _memory_page_acl_cache={}
 _config_file_cache = {}
 _cfg_table_cache = {}
@@ -278,7 +278,7 @@ g_tellme_pattern_cache = None
 
 
 
-# these 2 are going to play an important role  
+# these 2 are going to play an important role
 mnproc = None
 mndbg = None
 
@@ -354,7 +354,7 @@ class MnDebugger:
 	def isWinDBG(self):
 		if __DEBUGGERAPP__ == "WinDBG":
 			return True
-		return False		
+		return False
 
 	def isImmunity(self):
 		if __DEBUGGERAPP__ == "Immunity Debugger":
@@ -11757,12 +11757,12 @@ def normalizeHexBytesArg(pattern):
 
 	return txt
 
-def cleanHex(hex):
-	hex = hex.replace("'","")
-	hex = hex.replace('"',"")
-	hex = hex.replace("\\x","")
-	hex = hex.replace("0x","")
-	return hex
+def cleanHex(input_string):
+	input_string = input_string.replace("'","")
+	input_string = input_string.replace('"',"")
+	input_string = input_string.replace("\\x","")
+	input_string = input_string.replace("0x","")
+	return input_string
 
 def hex2int(hex):
 	return int(hex,16)
@@ -13665,7 +13665,7 @@ def getModuleObj(modname):
 		modname_search = modname + suf	
 		
 		#WinDBG optimized
-		if mndbg.isWinDBG():	
+		if mndbg.isWinDBG():
 			for tmod_s in allmod:
 				tmod = dbgGetModuleSafe(tmod_s)
 				if not tmod == None:
@@ -14187,7 +14187,7 @@ class MnEncoder:
 			revval=hexStrToInt(reversebytes)			   
 			twoval=4294967296-revval
 			twobytes=toHex(twoval)
-			if not g_silent:	
+			if not g_silent:
 				dbg.log("Opcode to produce : %s%s %s%s %s%s %s%s" % (origbytes[0],origbytes[1],origbytes[2],origbytes[3],origbytes[4],origbytes[5],origbytes[6],origbytes[7]))
 				dbg.log("         reversed : %s%s %s%s %s%s %s%s" % (reversebytes[0],reversebytes[1],reversebytes[2],reversebytes[3],reversebytes[4],reversebytes[5],reversebytes[6],reversebytes[7]))
 				dbg.log("                    -----------")				   
@@ -14895,7 +14895,7 @@ class MnLog:
 			thispid = dbg.getDebuggedPid()
 			if thispid == 0:
 				debuggedname = "_no_name_"
-			
+
 			thisconfig = MnConfig()
 			workingfolder = thisconfig.get("workingfolder").rstrip("\\").strip()
 			mndbg.dbgp("Workingfolder: %s" % workingfolder)
@@ -14906,7 +14906,7 @@ class MnLog:
 			debuggedname = debuggedname[0:len(debuggedname)-extlen]
 			debuggedname = debuggedname.replace(" ","_")
 			workingfolder = workingfolder.replace('%p', debuggedname)
-			workingfolder = workingfolder.replace('%i', str(thispid))		
+			workingfolder = workingfolder.replace('%i', str(thispid))
 			#logfile = workingfolder + "\\" + self.filename
 			# working folder will be created inside getAbsolutePath if needed
 			logfile = getAbsolutePath(self.filename)
@@ -16105,7 +16105,7 @@ class MnModule: # TODO: Add getters
 				
 				# METHOD 1 - Parse the strings from the IAT.  Fastest way
 				if not g_silent:
-					dbg.log("      Enumerating IAT, method 1 (Read IAT from memory)") 
+					dbg.log("      Enumerating IAT, method 1 (Read IAT from memory)")
 				# find optional header
 				PEHeader_ref = self.moduleBase + 0x3c
 				PEHeader_location = self.moduleBase + struct.unpack('<L', dbg.readMemory(PEHeader_ref, 4))[0]
@@ -16254,7 +16254,7 @@ class MnModule: # TODO: Add getters
 				if len(IAT) < 10:
 					before_method2_cnt = len(IAT)
 					if not g_silent:
-						dbg.log("      Enumerating IAT, method 2 (Symbols - this might take a while)") 
+						dbg.log("      Enumerating IAT, method 2 (Symbols - this might take a while)")
 					# this may not work well on Immunity.  Module.getSymbols() may not return anything         
 					try:
 						themod = dbgGetModuleSafe(self.moduleKey)
@@ -19551,7 +19551,7 @@ class MnChunk(MnListEntry):
 		mndbg.dbgp("    Segment walk done: seg=%s iterations=%d decode_failures=%d zero_steps=%d last_hits=%d max_step=0x%x elapsed=%.2fs" % (
 			PTR_PRINT % segment_base, itercnt, decode_failures, zero_size_steps, last_flag_hits,
 			max_step, time.time() - walk_start))
-		
+
 		interruptMona()
 
 
@@ -19593,7 +19593,7 @@ class MnChunk(MnListEntry):
 			return (0, 0)
 		if offset != None:
 			start = start + offset
-			size = size - offset 
+			size = size - offset
 
 		fillbyte = _normalize_single_fill_byte(fillchar)
 		if len(fillbyte) == 0:
@@ -20574,12 +20574,12 @@ class MnPointer:
 			start, end, category, description = region[0], region[1], region[2], region[3]
 			size  = end - start if end > start else 0
 			psize = "0x%x" % size
-			dbgp("  %s, category %s, description %s" % (PTR_PRINT % start, category, description) )	
+			dbgp("  %s, category %s, description %s" % (PTR_PRINT % start, category, description) )
 
 
 	def showObjectInfo(self):
 		# check if chunk is a DOM object
-		
+
 		if mndbg.isWinDBG():
 			cmdtorun = "dps %s L 1" % (PTR_PRINT % self.address)
 			output = dbg.nativeCommand(cmdtorun)
@@ -20905,7 +20905,7 @@ class MnPointer:
 
 	def showHeapStackTrace(self,thischunk):
 		# show stacktrace if any
-		if mndbg.isWinDBG(): 
+		if mndbg.isWinDBG():
 			stacktrace_address = thischunk.dph_block_information_stacktrace
 			stacktrace_index = thischunk.dph_block_information_traceindex
 			stacktrace_startstamp = 0xabcdaaaa
@@ -23442,7 +23442,7 @@ def findROPGADGETS(modulecriteria={},criteria={},endings=[],maxoffset=40,depth=5
 					dbg.updateLog()
 					mndbg.dbgp("Number of ropgadgets: %d" % len(ropgadgets))
 					mndbg.dbgp("Number of stackpivots: %d" % len(stackpivots))
-					mndbg.dbgp("Number of safeseh stackpivots: %d" % len(stackpivots_safeseh))					
+					mndbg.dbgp("Number of safeseh stackpivots: %d" % len(stackpivots_safeseh))
 					tc += 1				
 				if not usefiles:
 					#first get max backward instruction
@@ -23485,7 +23485,7 @@ def findROPGADGETS(modulecriteria={},criteria={},endings=[],maxoffset=40,depth=5
 									#if DEBUG_MODE:
 									#	mndbg.dbgp("Address 0x%x passed the isGoodGadgetPtr test" % startptr)
 									invalidinstr = False
-									#mndbg.dbgp("Chainptr 0x%08x, Endingtypeptr 0x%08x, Invalidinstr: %s (Before start of loop)" % (chainptr, endingtypeptr, invalidinstr))	
+									#mndbg.dbgp("Chainptr 0x%08x, Endingtypeptr 0x%08x, Invalidinstr: %s (Before start of loop)" % (chainptr, endingtypeptr, invalidinstr))
 									avoidunlimitedloop = 0
 									while chainptr < endingtypeptr and not invalidinstr and avoidunlimitedloop < 100:
 										thisopcode = dbg.disasm(chainptr)
@@ -23511,7 +23511,7 @@ def findROPGADGETS(modulecriteria={},criteria={},endings=[],maxoffset=40,depth=5
 										if not startptr in _invalid_instr_cache:
 											_invalid_instr_cache.add(startptr)
 											_invalid_instr_cache_stores += 1
-									mndbg.dbgp("Chain at 0x%x, Endingtypeptr 0x%x,  Invalidinstr: %s, endingtypeptr , chain %s" % (startptr, endingtypeptr, invalidinstr, thischain))				
+									mndbg.dbgp("Chain at 0x%x, Endingtypeptr 0x%x,  Invalidinstr: %s, endingtypeptr , chain %s" % (startptr, endingtypeptr, invalidinstr, thischain))
 									if endingtypeptr == chainptr and startptr != chainptr and not invalidinstr:
 										if not startptr in ropgadgets:
 											fullchain = thischain + " # " + endingtype.lower()
@@ -23544,7 +23544,7 @@ def findROPGADGETS(modulecriteria={},criteria={},endings=[],maxoffset=40,depth=5
 											if bypasscfg and iscfg:
 												# only allow CFG Compatible pointers 
 												cfg_compatible_pointer = modinfo.checkCFGCompatible(startptr)
-												mndbg.dbgp("Is %s (%s) CFG compatible? %s " % (PTR_PRINT % startptr,currentmodulename, cfg_compatible_pointer))											
+												mndbg.dbgp("Is %s (%s) CFG compatible? %s " % (PTR_PRINT % startptr,currentmodulename, cfg_compatible_pointer))
 												if cfg_compatible_pointer:
 													valid_cfg_target_gadgets.append(startptr)
 													mndbg.dbgp("Added %s to CFG Compatible gadgets " % (PTR_PRINT % startptr))
@@ -23603,7 +23603,7 @@ def findROPGADGETS(modulecriteria={},criteria={},endings=[],maxoffset=40,depth=5
 	mndbg.dbgp("Final Number of ropgadgets: %d" % len(ropgadgets))
 	mndbg.dbgp("Final Number of stackpivots: %d" % len(stackpivots))
 	mndbg.dbgp("Final Number of safeseh stackpivots: %d" % len(stackpivots_safeseh))
-	mndbg.dbgp("Final Number of valid CFG target gadgets: %d" % len(valid_cfg_target_gadgets))			
+	mndbg.dbgp("Final Number of valid CFG target gadgets: %d" % len(valid_cfg_target_gadgets))
 	invalid_instr_cache_hits, invalid_instr_cache_requests, invalid_instr_cache_stores, invalid_instr_cache_pct = getInvalidInstrCacheStats()
 
 	mndbg.dbgp("Invalid instruction cache stats: %d hit(s) / %d request(s), %d stored (%.2f%%)" % (
@@ -23801,7 +23801,7 @@ def findROPGADGETS(modulecriteria={},criteria={},endings=[],maxoffset=40,depth=5
 			except:
 				pass
 			_writeMarkdownTextFenceEnd(logfile, thislog)
-			
+
 
 		if not split:
 			dbg.log("")
@@ -23912,7 +23912,7 @@ def findROPGADGETS(modulecriteria={},criteria={},endings=[],maxoffset=40,depth=5
 				except:
 					pass
 				_writeMarkdownTextFenceEnd(logfile, thislog)
-			
+
 		else:
 			dbg.log("[+] Writing results to individual files (grouped by module)")
 			dbg.updateLog()
@@ -24441,7 +24441,7 @@ def findOffsetInPattern(searchpat,size=20280,args = {}):
 	oldsilent=g_silent
 	
 	for mode in modes:
-		g_silent=oldsilent		
+		g_silent=oldsilent
 		if mode == "normal":
 			g_silent=True
 			mspattern=createPattern(size,args)
@@ -25363,7 +25363,7 @@ def findPatternWild(modulecriteria,criteria,pattern,base,top,patterntype):
 	patterntype - type of search to conduct (str or bin)
 	"""
 	
-	global g_silent	
+	global g_silent
 	
 	rangestosearch = []
 	tmpsearch = []
@@ -25624,7 +25624,7 @@ def findPattern(modulecriteria,criteria,pattern,ptype,base,top,consecutive=False
 	rangestosearch = []
 	tmpsearch = []
 	p2prangestosearch = []
-	global g_silent	
+	global g_silent
 	if len(modulecriteria) > 0:
 		modulestosearch = getModulesToQuery(modulecriteria)
 		# convert modules to ranges
@@ -25689,7 +25689,7 @@ def findPattern(modulecriteria,criteria,pattern,ptype,base,top,consecutive=False
 	patternfilename = ""
 	split1 = re.compile(' ')		
 	split2 = re.compile(':')
-	split3 = re.compile("\\*")		
+	split3 = re.compile("\\*")
 	
 	if not g_silent:
 		dbg.log("    - Treating search pattern as %s" % ptype)
@@ -26641,7 +26641,7 @@ def guess_bad_chars(cmp, log, logsilent, mapping=None):
 	return guessed_badchars
 
 
-def memcompare(location, src, comparetable, sctype, smart=True, tablecols=16):
+def memcompare(location, src, comparetable, sctype="normal", smart=True, tablecols=16):
 	''' Thoroughly compares an input binary string with a location in memory
 	and outputs the results. '''
 
@@ -26659,7 +26659,7 @@ def memcompare(location, src, comparetable, sctype, smart=True, tablecols=16):
 		locinfo = MnPointer(location).memLocation()
 		badbstr = " "
 		if len(badbytes) > 0:
-			badbstr = "%s " % bin2hex(sorted(badbytes))
+			badbstr = bin2hex(sorted(badbytes))
 		comparetable.add(0, ['0x%08x' % location, msg, badbstr, sctype, locinfo])
 
 	objlogfile.write("-" * 100, logfile)
@@ -26826,7 +26826,7 @@ def createRopChains(suggestions,interestinggadgets,allgadgets,modulecriteria,cri
 		dbg.log("[+] %s" % updatetxt)
 		objprogressfile.write("- " + updatetxt,progressfile)
 		vplogtxt += "\n"
-		vplogtxt += "\n\n### Register setup for " + routine + "() :\n" 
+		vplogtxt += "\n\n### Register setup for " + routine + "() :\n"
 		vplogtxt += routinesetup[routine] + "\n\n"
 		targetOS = "(XP/2003 Server and up)"
 		if routine == "SetInformationProcess":
@@ -27047,10 +27047,10 @@ def createRopChains(suggestions,interestinggadgets,allgadgets,modulecriteria,cri
 					type = "ptr"
 					al = criteria["accesslevel"]
 					criteria["accesslevel"] = "R"
-					g_ptr_counter = 0				
+					g_ptr_counter = 0
 					g_ptr_to_get = 2
 					oldsilent = g_silent
-					g_silent=True				
+					g_silent=True
 					allpointers = findPattern(modulecriteria,criteria,pattern,type,base,top)
 					g_silent = oldsilent
 					criteria["accesslevel"] = al
@@ -27312,7 +27312,7 @@ def createRopChains(suggestions,interestinggadgets,allgadgets,modulecriteria,cri
 		vplogtxt += "```\n"
 		# Python
 		vplogtxt += "\n```python\n"
-		vplogtxt += "*** [ Python ] ***\n\n"		
+		vplogtxt += "*** [ Python ] ***\n\n"
 		vplogtxt += "  def create_rop_chain(%s):\n" % argtxt
 		vplogtxt += "\n    # rop chain generated with mona.py - www.corelan.be\n"			
 		vplogtxt += "    rop_gadgets = [\n"
@@ -27648,12 +27648,12 @@ def getPickupGadget(targetreg,targetval,freetext,suggestions,interestinggadgets,
 			criteria["accesslevel"] = "X"
 			global g_ptr_to_get
 			global g_ptr_counter
-			g_ptr_counter = 0				
+			g_ptr_counter = 0
 			g_ptr_to_get = 5
 			theptr = 0
 			global g_silent
 			oldsilent = g_silent
-			g_silent=True				
+			g_silent=True
 			allpointers = findPattern(modulecriteria,criteria,pattern,type,base,top)
 			g_silent = oldsilent
 			criteria["accesslevel"] = al
@@ -27703,7 +27703,7 @@ def getRopFuncPtr(apiname,modulecriteria,criteria,mode, objprogressfile, progres
 	oldsilent = g_silent
 	g_silent = True
 	global g_ptr_to_get
-	g_ptr_to_get = -1	
+	g_ptr_to_get = -1
 	rfuncsearch = apiname.lower()
     
 	selectedmodules = False
@@ -29806,7 +29806,7 @@ def args2criteria(args,modulecriteria,criteria):
 	if "p" in args:
 		if str(args["p"]).lower() != "true":
 			g_ptr_to_get = int(args["p"].strip())
-		if g_ptr_to_get > 0:	
+		if g_ptr_to_get > 0:
 			dbg.log("    - Maximum nr of pointers to return : %d" % g_ptr_to_get)
 	
 	# only want to see specific type of pointers ?
@@ -29825,14 +29825,8 @@ def args2criteria(args,modulecriteria,criteria):
 			args["cpb"] = args["cbp"]
 	
 	if "cpb" in args:
-		strb, badcharsok = cpbArgToBytes(args["cpb"])
-		if not badcharsok:
-			dbg.log("    * Unable to parse -cpb value '%s'" % args["cpb"], highlight=True)
-			return modulecriteria,criteria
-		criteria["badchars"] = strb
-		badchars_printable = "\\x" + "\\x".join(bin2hex(strb).split(" "))
-		dbg.log("    - Bad char filter will be applied to pointers : %s " % badchars_printable)
-
+		criteria["badchars"] = b"".join(parse_cpb_input(args["cpb"]))
+		dbg.log("    - Bad char filter will be applied to pointers : %s " % args["cpb"])
 			
 	if "cm" in args:
 		modcriteria = args["cm"].split(",")
@@ -30136,7 +30130,7 @@ def procCleanLog(args):
 						if thisfile_lc.endswith(".old2"):
 							matches = True
 						if "tellme" in thisfile_lc and thisfile_lc.endswith(".json"):
-							matches = True	
+							matches = True
 						if "rop" in thisfile_lc and "progress" in thisfile_lc and thisfile_lc.endswith(".log"):
 							matches = True
 						if "bridge" in thisfile_lc and thisfile_lc.endswith(".log"):
@@ -31740,7 +31734,7 @@ def procInfo(args):
 			reasonlines = reason.split('\n')
 			for reasonline in reasonlines:
 				dbg.log("    -> %s" % reasonline)
-								
+
 	else:
 		output = ""
 		if ptr.isInHeap():
@@ -33974,35 +33968,91 @@ def procDump(args):
 
 # ----- compare : Compare a file created by msfvenom/gdb/hex/xxd/hexdump/ollydbg or just a file with raw bytes with a copy in memory, indicate bad chars / corruption ----- #
 def procCompare(args):
-	startpos = 0
-	filename = ""
-	skipmodules = False
-	findunicode = False
-	allregs = getRegisters()
-	if "f" in args:
-		filename = getAbsolutePath(args["f"].replace('"',"").replace("'",""))
-		#see if we can read the file
-		if not os.path.isfile(filename):
-			dbg.log("Unable to find/read file %s" % filename,highlight=1)
-			return
-	else:
-		dbg.log("You must specify a valid filename using parameter -f", highlight=1)
-		return
+	memory_search_start_pos = 0
+	skip_modules = False
+	find_unicode = False
+	char_array_args = {}
+	search_mode = "normal"
 	if "a" in args:
-		startpos,addyok = getAddyArg(args["a"])
+		memory_search_start_pos,addyok = getAddyArg(args["a"])
 		if not addyok:
 			dbg.log("%s is an invalid address" % args["a"], highlight=1)
 			return
 	if "s" in args:
-		skipmodules = True
+		skip_modules = True
 	if "unicode" in args:
-		findunicode = True
+		find_unicode = True
+	if "cpb" in args:
+		char_array_args["cpb"] = args["cpb"]
 	if "t" in args:
-		format = args["t"]
+		file_format = args["t"]
 	else:
-		format = None
-	compareFormattedFileWithMemory(filename,format,startpos,skipmodules,findunicode)				
-	
+		file_format = None
+	if "f" in args:
+		file_name = getAbsolutePath(args["f"].replace('"',"").replace("'",""))
+		if not os.path.isfile(file_name):
+			dbg.log("Unable to find/read file %s" % file_name,highlight=1)
+			return
+		compareFormattedFileWithMemory(file_name, file_format, memory_search_start_pos, skip_modules, find_unicode)
+	else:
+		if find_unicode: raise NotImplementedError("compare does not yet support unicode search")
+		comparison_output_table = dbg.createTable('mona Memory comparison results',
+		                               ['Address', 'Status', 'BadChars', 'Type', 'Location'])
+		char_array = bad_char_comparison_array(char_array_args)
+		# memcompare expects a list of single char strings, not bytes, so:
+		char_string_array = []
+		for char in char_array:
+			char_string_array.append(chr(char))
+		memcompare(memory_search_start_pos, char_string_array, comparison_output_table)
+
+def parse_undelimited_cpb(input_string):
+	hex_char_list = []
+	parsed_string = ""
+	zipped_chars = zip(input_string[::2], input_string[1::2])
+	for char_first, char_second in zipped_chars:
+		hex_char_list.append(char_first + char_second)
+	for index, char in enumerate(hex_char_list):
+		try:
+			if hex_char_list[index + 1] == ".." or hex_char_list[index - 1] == "..":
+				continue
+			elif char == "..":
+				parsed_string += f"{hex_char_list[index - 1]}..{hex_char_list[index + 1]},"
+				continue
+		except Exception:
+			continue
+		else: parsed_string += f"{char},"
+	return parse_cpb_input(parsed_string[:-1])
+
+
+def parse_cpb_input(user_input):
+	user_input = cleanHex(user_input)
+	user_input = user_input.replace(":", ",")
+	user_input_list = user_input.split(",")
+	bad_chars_list = []
+	for input_substring_entry in user_input_list:
+		if len(input_substring_entry) == 2:
+			bad_char = bytes.fromhex(input_substring_entry)
+			bad_chars_list.append(bad_char)
+		elif len(input_substring_entry) == 6 and input_substring_entry[2:4] == "..":
+			start_bad_char = bytes.fromhex(input_substring_entry[0:2])
+			end_bad_char = bytes.fromhex(input_substring_entry[4:6])
+			for char_index in range(int.from_bytes(start_bad_char), int.from_bytes(end_bad_char)):
+				bad_chars_list.append(char_index.to_bytes())
+			bad_chars_list.append(end_bad_char)
+		else: bad_chars_list + parse_undelimited_cpb(input_substring_entry)
+	return bad_chars_list
+
+def bad_char_comparison_array(args):
+	bad_chars_list = []
+	if "cpb" in args:
+		bad_chars_list = parse_cpb_input(args["cpb"])
+	char_array_list = []
+	for char in range(0x00, 0xFF+1): # for X in range() does not include final number, so +1 to account for that
+		if bytes([char]) not in bad_chars_list:
+			char_array_list.append(char)
+	char_array = bytes(char_array_list)
+	return char_array
+
 # ----- offset: Calculate the offset between two addresses ----- #
 def procOffset(args):
 	extratext1 = ""
@@ -34249,16 +34299,10 @@ def procByteArray(args):
 			if not "cpb" in args:
 				args["cpb"] = args["b"]
 
-	strb = b""
 	if "cpb" in args:
-		strb, badcharsok = cpbArgToBytes(args["cpb"])
-		if not badcharsok:
-			dbg.log(" *** Unable to parse -cpb value '%s' ***" % args["cpb"], highlight=1)
-			return
+		bad_chars = b"".join(parse_cpb_input(args["cpb"]))
 
-	badchars_printable = "\\x" + "\\x".join(bin2hex(strb).split(" "))
-	dbg.log("Generating table, excluding %d bad chars: %s" % (len(strb), badchars_printable))
-
+	dbg.log("Generating table, excluding %d bad chars..." % len(bad_chars))
 	arraytable = []
 	binarray = b""
 
@@ -34277,7 +34321,7 @@ def procByteArray(args):
 		if len(hexbyte) == 1:
 			hexbyte = "0" + hexbyte
 		hexbyte2 = binascii.a2b_hex(hexbyte)
-		if not hexbyte2 in strb:
+		if not hexbyte2 in bad_chars:
 			arraytable.append(hexbyte)
 			binarray += binbyte
 
@@ -35637,7 +35681,7 @@ def procUpdate(args):
 					cmdname = clickWinDBGCmd(windbg_cmd = "%s up -force" % getAliasName())
 					dbg.log("        Run %s to overwrite your local copy anyway" % cmdname, highlight=1)
 				else:
-					dbg.log("        Run '%s up -force' to overwrite your local copy anyway" % getAliasName(), highlight=1)					
+					dbg.log("        Run '%s up -force' to overwrite your local copy anyway" % getAliasName(), highlight=1)
 				mndbg.dbgp("Same version/revision but file contents differ for %s" % name)
 			else:
 				dbg.log("    [+] You are already running the latest version of %s" % name)
@@ -35777,7 +35821,7 @@ def procEgg(args):
 	
 	global g_silent
 	oldsilent = g_silent
-	g_silent = True			
+	g_silent = True
 	
 	if "f" in args:
 		if type(args["f"]).__name__.lower() != "bool":
@@ -36147,7 +36191,7 @@ def procEgg(args):
 	
 	egghunter = startat + egghunter
 	
-	g_silent = oldsilent			
+	g_silent = oldsilent
 	
 	#Convert binary to printable hex format
 	egghunter_hex = toniceHex(egghunter.strip().replace(b" ",b""),16)
@@ -36277,7 +36321,7 @@ def procSuggest(args):
 	exploitfilename="exploit.rb"
 	objexploitfile = MnLog(exploitfilename)
 
-	#g_ptr_to_get = 5				
+	#g_ptr_to_get = 5
 	g_no_header = True
 	exploitfile = objexploitfile.reset(showheader = False, skipModuleTable=True)			
 	g_no_header = False
@@ -36416,11 +36460,11 @@ def procSuggest(args):
 					# can we find a jmp to that reg ?
 					g_silent = True
 					g_ptr_counter = 0
-					g_ptr_to_get = 1								
+					g_ptr_to_get = 1
 					jmp_pointers = findJMP(modulecriteria,eipcriteria,reg.lower())
 					if len( jmp_pointers ) == 0:
 						g_ptr_counter = 0
-						g_ptr_to_get = 1								
+						g_ptr_to_get = 1
 						modulecriteria["os"] = True
 						jmp_pointers = findJMP(modulecriteria,eipcriteria,reg.lower())
 					modulecriteria["os"] = False
@@ -36578,7 +36622,7 @@ def procSuggest(args):
 		#get SEH pointers
 		g_silent = True
 		g_ptr_counter = 0
-		g_ptr_to_get = 1					
+		g_ptr_to_get = 1
 		seh_pointers = findSEH(modulecriteria,sehcriteria)
 		jmpback = False
 		g_silent = False
@@ -36592,7 +36636,7 @@ def procSuggest(args):
 						sehcriteria.pop("nonull")
 						g_silent = True
 						g_ptr_counter = 0
-						g_ptr_to_get = 1									
+						g_ptr_to_get = 1
 						seh_pointers = findSEH(modulecriteria,sehcriteria)
 						g_silent = False
 						jmpback = True
@@ -37116,17 +37160,17 @@ def _procHeapByAddr(refvalue):
 		chunkDict[entry_str] = [uptr_str, chunk.usersize]
 		headers = ["_HEAP_ENTRY", "UserPtr", "UserSize"]
 		types = ["string", "string", "size"]
-		dbg.log("    %s found in Heap %s, %s:" % (label, heap_str, ctx))  
+		dbg.log("    %s found in Heap %s, %s:" % (label, heap_str, ctx))
 		print_dict_table(chunkDict, headers, types, padding = "    ", itemsequence = [])
-		
+
 		dbg.log("    State : %s (0x%02x)" % (chunk.flagtxt, chunk.flag))
-		# to do: 
+		# to do:
 		# if pointer at UserPtr is a symbol, print the symbol
 
 		# if pointer at UserPtr is part of a module, print the module
 
 		# is there a string at UserPtr or UserPtr+PTR_SIZE
-		startpos_offsets = [0, 4, 8] 
+		startpos_offsets = [0, 4, 8]
 		stringfound=False
 		stringfoundat = 0
 		string_to_print = ""
@@ -37154,7 +37198,7 @@ def _procHeapByAddr(refvalue):
 						break
 				except:
 					continue
-		
+
 		if stringfound:
 			# only print the first 40 chars
 			dbg.log("    Chunk contains start of a %s string @%s : '<b>%s</b>'" % (string_type, PTR_PRINT % stringfoundat, string_to_print[:40] ))
@@ -38929,9 +38973,9 @@ def procFillChunk(args):
 			write_offset = _determineWriteOffset(userptr)
 			if write_offset > 0:
 				dbg.log("")
-			
+
 			dbg.log("[+] Filling chunk with \\x%s, starting at %s, skipping %d bytes" % (
-						bin2hex(fillchar), (PTR_PRINT % userptr), write_offset))				
+						bin2hex(fillchar), (PTR_PRINT % userptr), write_offset))
 			fillbyte = _normalize_single_fill_byte(fillchar)
 			if len(fillbyte) == 0:
 				dbg.log("    ** Invalid fill byte specified **", highlight=1)
@@ -39683,8 +39727,7 @@ def procEnc(args):
 			byteerror = True
 
 	if "cpb" in args:
-		if type(args["cpb"]).__name__.lower() != "bool":
-			badbytes = hex2bin(args["cpb"])
+		bad_chars = b"".join(parse_cpb_input(args["cpb"]))
 
 	if not encodertype in validencoders:
 		encodertyperror = True
@@ -41730,7 +41773,7 @@ def getBanner():
 	bannertext += "    |       | | | | | || (_) || | | || (_| | _ | |_) || |_| |          |\n"
 	bannertext += "    |       |_| |_| |_| \\___/ |_| |_| \\__,_|(_)| .__/  \\__, |          |\n"
 	bannertext += "    |                                          |_|     |___/           |\n"
-	bannertext += "    \\------------------------------------------------------------------/\n"	
+	bannertext += "    \\------------------------------------------------------------------/\n"
 	banners[1] = bannertext
 
 	bannertext = ""
@@ -42195,21 +42238,26 @@ Optional arguments:
     -e <address> : the end address of the copy"""
 	
 
-	compareUsage = """Compare a file created by mona's bytearray/msfvenom/gdb/hex/xxd/hexdump/ollydbg with a copy in memory.
+	compareUsage = """Compare a bad characters array or a file created by mona's bytearray/msfvenom/gdb/hex/xxd/hexdump/ollydbg with a copy in memory.
 
 Mandatory argument :
     -f <filename> : full path to input file
 
-Optional argument :
+
+Optional arguments :
+    -cpb <bytes> : bytes to exclude from the comparison array. Example : '\\x00\\x0a\\x0d'
+                   Note: Does not work when file specified for comparison array with -f
+                   Note: you can specify ranges using .. 
+                   Example: '\\x00\\x0a..\\x20\\x32\\x7f..\\xff'
     -a <address> : the exact address of the bytes in memory (address or register). 
                    If you don't specify an address, I will try to locate the bytes in memory 
                    by looking at the first 8 bytes.
     -s : skip locations that belong to a module
     -unicode : perform unicode search. Note: input should *not* be unicode, it will be expanded automatically
     -t : input file type format. If no file type format is specified, I will try to guess the input file type format.
-	 
-    Available formats:
-    'raw', 'hexdump', 'js-unicode', 'dword', 'xxd', 'byte-array', 'hexstring', 'hexdump-C', 'classic-hexdump', 'escaped-hexes', 'msfvenom-powershell', 'gdb', 'ollydbg', 'msfvenom-ruby', 'msfvenom-c', 'msfvenom-carray', 'msfvenom-python'"""
+	-f <filename> : full path to input file to compare bytes in memory with
+                    Available formats:
+                    'raw', 'hexdump', 'js-unicode', 'dword', 'xxd', 'byte-array', 'hexstring', 'hexdump-C', 'classic-hexdump', 'escaped-hexes', 'msfvenom-powershell', 'gdb', 'ollydbg', 'msfvenom-ruby', 'msfvenom-c', 'msfvenom-carray', 'msfvenom-python'"""
 
 	offsetUsage = """Calculate the number of bytes between two addresses. 
 In addition to plain addresses, you can also specify registers, modules, module!functionnames, etc.
@@ -42443,7 +42491,7 @@ Optional arguments:
 
 Optional arguments:
     -s <keywords> : only show EAT entries that contain one of these keywords"""
-	
+
 
 	fillchunkUsage = """Fills a heap chunk, referenced by an address expression, with A's (or another character)
 
@@ -43052,7 +43100,7 @@ Official model docs:
 	commands["help"] 			= MnCommand("help", "Show help", "   %s help [command]" % launchcmd,procHelp,"h",[32,64])
 	commands["seh"] 			= MnCommand("seh", "Find pointers to assist with SEH overwrite exploits",sehUsage, procFindSEH)
 	commands["config"] 			= MnCommand("config","Manage configuration file (mona.ini)",configUsage,procConfig,"conf",[32,64])
-	commands["cleanlog"]        = MnCommand("cleanlog","Remove old log files from your workingfolder",cleanLogUsage,procCleanLog,"clean",[32,64])   
+	commands["cleanlog"]        = MnCommand("cleanlog","Remove old log files from your workingfolder",cleanLogUsage,procCleanLog,"clean",[32,64])
 	commands["jmp"]				= MnCommand("jmp","Find pointers that will allow you to jump to a register",jmpUsage,procFindJMP, "j",[32,64])
 	commands["ropfunc"] 		= MnCommand("ropfunc","Find pointers to pointers (IAT) to interesting functions that can be used in your ROP chain",ropfuncUsage,procFindROPFUNC,"rf",[32,64])
 	commands["rop"] 			= MnCommand("rop","Finds gadgets that can be used in a ROP chain and perhaps do some ROP magic with them",ropUsage,procROP,"",[32,64])
@@ -43421,7 +43469,7 @@ def main(args):
 
 		if command == "" or command == "-h":
 			command = "help"
-		
+
 
 		# is user trying to run a valid command or alias?
 		if command in acceptedcommands or command in acceptedaliases:

--- a/mona.py
+++ b/mona.py
@@ -26588,7 +26588,7 @@ def guess_bad_chars(cmp, log, logsilent, mapping=None):
 	if mapping:
 		for x, y in mapping:
 			if x != y:
-				first_broken_src = x
+				first_broken_src = ord(x)
 				break
 
 	for i, c in enumerate(chunks):
@@ -26630,7 +26630,7 @@ def guess_bad_chars(cmp, log, logsilent, mapping=None):
 			guessed_badchars.append(b)
 
 	# List bytes already omitted from the input
-	bytes_omitted_from_input = set(chr(i) for i in range(0, 256)) - set(cmp.x)
+	bytes_omitted_from_input = set(i for i in range(0, 256)) - set(cmp.x)
 	if bytes_omitted_from_input:
 		if not logsilent:
 			log(f"Bytes omitted from input: {bin2hex(sorted(set(list(bytes_omitted_from_input))))}")

--- a/mona.py
+++ b/mona.py
@@ -26611,21 +26611,21 @@ def guess_bad_chars(cmp, log, logsilent, mapping=None):
 
 	if first_broken_src is not None:
 		if not logsilent:
-			log("First mismatching byte: %s" % bin2hex(first_broken_src))
+			log(f"First mismatching byte: {bin2hex(first_broken_src)}")
 		if first_broken_src not in guessed_badchars:
 			guessed_badchars.append(first_broken_src)
 
 	if likely_bc:
 		if not logsilent:
-			log("Very likely bad chars: %s" % bin2hex(sorted(set(likely_bc))))
+			log(f"Very likely bad chars: {bin2hex(sorted(set(list(likely_bc))))}")
 		for b in likely_bc:
 			if b not in guessed_badchars:
 				guessed_badchars.append(b)
 
 	if not logsilent and len(bytes_in_changed_blocks) > 0:
-		log("Possibly bad chars: %s" % bin2hex(sorted(bytes_in_changed_blocks)))
+		log(f"Possibly bad chars: {bin2hex(sorted(set(list(bytes_in_changed_blocks))))}")
 
-	for b in sorted(bytes_in_changed_blocks):
+	for b in bytes_in_changed_blocks:
 		if b not in guessed_badchars:
 			guessed_badchars.append(b)
 
@@ -26633,7 +26633,7 @@ def guess_bad_chars(cmp, log, logsilent, mapping=None):
 	bytes_omitted_from_input = set(chr(i) for i in range(0, 256)) - set(cmp.x)
 	if bytes_omitted_from_input:
 		if not logsilent:
-			log("Bytes omitted from input: %s" % bin2hex(sorted(bytes_omitted_from_input)))
+			log(f"Bytes omitted from input: {bin2hex(sorted(set(list(bytes_omitted_from_input))))}")
 		for b in sorted(bytes_omitted_from_input):
 			if b not in guessed_badchars:
 				guessed_badchars.append(b)
@@ -26659,7 +26659,7 @@ def memcompare(location, src, comparetable, sctype="normal", smart=True, tableco
 		locinfo = MnPointer(location).memLocation()
 		badbstr = " "
 		if len(badbytes) > 0:
-			badbstr = bin2hex(sorted(badbytes))
+			badbstr = bin2hex(badbytes)
 		comparetable.add(0, ['0x%08x' % location, msg, badbstr, sctype, locinfo])
 
 	objlogfile.write("-" * 100, logfile)
@@ -26668,7 +26668,11 @@ def memcompare(location, src, comparetable, sctype="normal", smart=True, tableco
 
 	mem = read_memory(dbg, location, 2 * len(src))
 	if smart:
-		cmp = MemoryComparator(src, mem)
+		# Convert list of single byte strs (src) to bytes object for MemoryComparator
+		src_bytes = b""
+		for byte_str in src:
+			src_bytes = src_bytes + bytes([ord(byte_str)])
+		cmp = MemoryComparator(src_bytes, mem)
 		mapped_chunks = [''.join(chr(_ord(b)) for b in chunk) for chunk in cmp.guess_mapping()]
 	else:
 		mapped_chunks = [chr(_ord(b)) for b in mem[:len(src)]] + [()] * (len(src) - len(mem))
@@ -34018,7 +34022,8 @@ def parse_undelimited_cpb(input_string):
 			elif char == "..":
 				parsed_string += f"{hex_char_list[index - 1]}..{hex_char_list[index + 1]},"
 				continue
-		except Exception:
+		except IndexError:
+			parsed_string += f"{char},"
 			continue
 		else: parsed_string += f"{char},"
 	return parse_cpb_input(parsed_string[:-1])
@@ -34039,7 +34044,7 @@ def parse_cpb_input(user_input):
 			for char_index in range(int.from_bytes(start_bad_char), int.from_bytes(end_bad_char)):
 				bad_chars_list.append(char_index.to_bytes())
 			bad_chars_list.append(end_bad_char)
-		else: bad_chars_list + parse_undelimited_cpb(input_substring_entry)
+		else: bad_chars_list = bad_chars_list + parse_undelimited_cpb(input_substring_entry)
 	return bad_chars_list
 
 def bad_char_comparison_array(args):


### PR DESCRIPTION
Following commands tested working in windbg (example values)
```
(Previous version)
!mona bytearray -b '\x00'
!mona compare -f C:\logs\somebin\bytearray.bin -a 0379fadc

(New feature)
!mona compare -cpb '\x00' -a 0379fadc
```

I've unfortunately not had the chance to perform exhaustive testing for edge case issues since I don't know all the possible tests needed.

(Also, my IDE decided to remove trailing whitespace throughout the codebase and it refused to not remove it so those changes are included - apologies for the bloat.)